### PR TITLE
Properly generate stub for non-MSVC compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(binkstub VERSION 1.0.0 LANGUAGES C)
 
-add_library(binkstub SHARED bink.c bink.def)
+add_library(binkstub SHARED bink.c)
 set_target_properties(binkstub PROPERTIES OUTPUT_NAME binkw32)
 set_target_properties(binkstub PROPERTIES SOVERSION 1.0 VERSION 1.0.0)
 target_include_directories(binkstub PUBLIC


### PR DESCRIPTION
In a similar fashion as for [miles-sdk-stub](https://github.com/TheSuperHackers/miles-sdk-stub/pull/2), remove the .def file from add_library in the CMakeLists.txt, which makes this project build successfully using mingw64 (i686-w64-mingw32-gcc).
The current implementation fails with errors like:

> /usr/bin/i686-w64-mingw32-ld: cannot export _BinkClose@4: symbol not defined
> /usr/bin/i686-w64-mingw32-ld: cannot export _BinkCopyToBuffer@28: symbol not defined
> /usr/bin/i686-w64-mingw32-ld: cannot export _BinkDoFrame@4: symbol not defined

etc.
